### PR TITLE
Add black theme

### DIFF
--- a/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/AppPreferences.kt
@@ -5,6 +5,7 @@ import me.msoul.datastore.defaultOf
 data class AppPreferences(
     val layoutMode: LayoutMode = defaultOf(),
     val themeMode: ThemeMode = defaultOf(),
+    val darkThemeMode: DarkThemeMode = defaultOf(),
     val colorScheme: ColorScheme = defaultOf(),
     val sortMethod: SortMethod = defaultOf(),
     val backupStrategy: BackupStrategy = defaultOf(),

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -18,7 +18,7 @@ enum class ThemeMode(override val nameResource: Int, val mode: Int) : HasNameRes
 }
 
 enum class DarkThemeMode(override val nameResource: Int, val styleResource: Int?) : HasNameResource, EnumPreference by key("dark_theme_mode") {
-    STANDARD(R.string.preferences_theme_dark_mode_standard, null) { override val isDefault = true },
+    GREY(R.string.preferences_theme_dark_mode_grey, null) { override val isDefault = true },
     BLACK(R.string.preferences_theme_dark_mode_black, R.style.DarkBlack),
 }
 

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -17,6 +17,11 @@ enum class ThemeMode(override val nameResource: Int, val mode: Int) : HasNameRes
     LIGHT(R.string.preferences_theme_mode_light, AppCompatDelegate.MODE_NIGHT_NO),
 }
 
+enum class DarkThemeMode(override val nameResource: Int, val styleResource: Int?) : HasNameResource, EnumPreference by key("dark_theme_mode") {
+    STANDARD(R.string.preferences_theme_dark_mode_standard, null) { override val isDefault = true },
+    BLACK(R.string.preferences_theme_dark_mode_black, R.style.DarkBlack),
+}
+
 enum class ColorScheme(
     override val nameResource: Int,
     val styleResource: Int,

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceEnums.kt
@@ -18,7 +18,7 @@ enum class ThemeMode(override val nameResource: Int, val mode: Int) : HasNameRes
 }
 
 enum class DarkThemeMode(override val nameResource: Int, val styleResource: Int?) : HasNameResource, EnumPreference by key("dark_theme_mode") {
-    GREY(R.string.preferences_theme_dark_mode_grey, null) { override val isDefault = true },
+    STANDARD(R.string.preferences_theme_dark_mode_standard, null) { override val isDefault = true },
     BLACK(R.string.preferences_theme_dark_mode_black, R.style.DarkBlack),
 }
 

--- a/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
+++ b/app/src/main/java/org/qosp/notes/preferences/PreferenceRepository.kt
@@ -33,6 +33,7 @@ class PreferenceRepository(
                 AppPreferences(
                     layoutMode = prefs.getEnum(),
                     themeMode = prefs.getEnum(),
+                    darkThemeMode = prefs.getEnum(),
                     colorScheme = prefs.getEnum(),
                     sortMethod = prefs.getEnum(),
                     backupStrategy = prefs.getEnum(),

--- a/app/src/main/java/org/qosp/notes/ui/BaseActivity.kt
+++ b/app/src/main/java/org/qosp/notes/ui/BaseActivity.kt
@@ -1,5 +1,6 @@
 package org.qosp.notes.ui
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.qosp.notes.preferences.PreferenceRepository
+import org.qosp.notes.preferences.ThemeMode
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -31,6 +33,21 @@ open class BaseActivity : AppCompatActivity() {
 
             if (themeMode != AppCompatDelegate.getDefaultNightMode()) {
                 AppCompatDelegate.setDefaultNightMode(themeMode)
+            }
+
+            val isAutoDark =
+                themeMode == ThemeMode.SYSTEM.mode && resources.configuration.uiMode == Configuration.UI_MODE_NIGHT_YES
+
+            if (themeMode == ThemeMode.DARK.mode || isAutoDark) {
+                val darkThemeModeStyle = withContext(Dispatchers.IO) {
+                    preferenceRepository
+                        .getAll()
+                        .map { it.darkThemeMode.styleResource }
+                        .first()
+                }
+                darkThemeModeStyle?.let {
+                    theme.applyStyle(darkThemeModeStyle, true)
+                }
             }
         }
     }

--- a/app/src/main/java/org/qosp/notes/ui/BaseActivity.kt
+++ b/app/src/main/java/org/qosp/notes/ui/BaseActivity.kt
@@ -22,10 +22,16 @@ open class BaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         runBlocking {
-            val (colorScheme, themeMode) = withContext(Dispatchers.IO) {
+            val (colorScheme, themeMode, darkThemeModeStyle) = withContext(Dispatchers.IO) {
                 preferenceRepository
                     .getAll()
-                    .map { it.colorScheme.styleResource to it.themeMode.mode }
+                    .map {
+                        Triple(
+                            it.colorScheme.styleResource,
+                            it.themeMode.mode,
+                            it.darkThemeMode.styleResource
+                        )
+                    }
                     .first()
             }
 
@@ -39,12 +45,6 @@ open class BaseActivity : AppCompatActivity() {
                 themeMode == ThemeMode.SYSTEM.mode && resources.configuration.uiMode == Configuration.UI_MODE_NIGHT_YES
 
             if (themeMode == ThemeMode.DARK.mode || isAutoDark) {
-                val darkThemeModeStyle = withContext(Dispatchers.IO) {
-                    preferenceRepository
-                        .getAll()
-                        .map { it.darkThemeMode.styleResource }
-                        .first()
-                }
                 darkThemeModeStyle?.let {
                     theme.applyStyle(darkThemeModeStyle, true)
                 }

--- a/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/settings/SettingsFragment.kt
@@ -42,6 +42,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
         setupPreferenceObservers()
         setupColorSchemeListener()
         setupThemeModeListener()
+        setupDarkThemeModeListener()
         setupLayoutModeListener()
         setupSortMethodListener()
         setupGroupNotesWithoutNotebookListener()
@@ -77,6 +78,7 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
                 }
                 binding.settingColorScheme.subText = getString(colorScheme.nameResource)
                 binding.settingThemeMode.subText = getString(themeMode.nameResource)
+                binding.settingDarkThemeMode.subText = getString(darkThemeMode.nameResource)
                 binding.settingLayoutMode.subText = getString(layoutMode.nameResource)
                 binding.settingLayoutMode.setIcon(
                     when (layoutMode) {
@@ -123,6 +125,15 @@ class SettingsFragment : BaseFragment(resId = R.layout.fragment_settings) {
                 if (selected.mode != AppCompatDelegate.getDefaultNightMode()) {
                     AppCompatDelegate.setDefaultNightMode(selected.mode)
                 }
+            }
+        }
+    }
+
+    private fun setupDarkThemeModeListener() = binding.settingDarkThemeMode.setOnClickListener {
+        showPreferenceDialog(R.string.preferences_dark_theme_mode, appPreferences.darkThemeMode) { selected ->
+            lifecycleScope.launch {
+                model.setPreference(selected)
+                activity?.recreate()
             }
         }
     }

--- a/app/src/main/res/drawable/ic_dark_mode_variant.xml
+++ b/app/src/main/res/drawable/ic_dark_mode_variant.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M14,2c1.82,0 3.53,0.5 5,1.35C16.01,5.08 14,8.3 14,12s2.01,6.92 5,8.65C17.53,21.5 15.82,22 14,22C8.48,22 4,17.52 4,12S8.48,2 14,2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -46,6 +46,13 @@
                     app:iconSrc="@drawable/ic_dark_mode"/>
 
             <org.qosp.notes.ui.utils.views.PreferenceView
+                    android:id="@+id/setting_dark_theme_mode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:text="@string/preferences_dark_theme_mode"
+                    app:iconSrc="@drawable/ic_dark_mode_variant"/>
+
+            <org.qosp.notes.ui.utils.views.PreferenceView
                     android:id="@+id/setting_color_scheme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="preferences_theme_mode_light">Light</string>
     <string name="preferences_theme_mode_system">Follow system</string>
 
+    <string name="preferences_dark_theme_mode">Dark theme mode</string>
+    <string name="preferences_theme_dark_mode_standard">Standard</string>
+    <string name="preferences_theme_dark_mode_black">Black</string>
+
     <string name="preferences_header_view">View</string>
     <string name="preferences_layout_mode">Layout mode</string>
     <string name="preferences_layout_mode_grid">Grid</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="preferences_theme_mode_system">Follow system</string>
 
     <string name="preferences_dark_theme_mode">Dark theme mode</string>
-    <string name="preferences_theme_dark_mode_standard">Standard</string>
+    <string name="preferences_theme_dark_mode_grey">Grey</string>
     <string name="preferences_theme_dark_mode_black">Black</string>
 
     <string name="preferences_header_view">View</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="preferences_theme_mode_system">Follow system</string>
 
     <string name="preferences_dark_theme_mode">Dark theme mode</string>
-    <string name="preferences_theme_dark_mode_grey">Grey</string>
+    <string name="preferences_theme_dark_mode_standard">Standard</string>
     <string name="preferences_theme_dark_mode_black">Black</string>
 
     <string name="preferences_header_view">View</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -47,12 +47,13 @@
 
     <style name="DarkBlack">
         <item name="colorBackground">#000</item>
+
         <item name="colorSurface">#1B1B1B</item>
         <item name="elevationOverlayEnabled">false</item>
+
         <item name="colorNoteDefault">#000</item>
-        <item name="colorDrawerBackground">#040404</item>
+        <item name="colorDrawerBackground">#191919</item>
         <item name="colorBottomAppBarBackground">#000</item>
-        <item name="android:navigationBarColor">#000</item>
     </style>
 
     <style name="Blue">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -45,6 +45,16 @@
         <item name="android:windowTranslucentStatus">true</item>
     </style>
 
+    <style name="DarkBlack">
+        <item name="colorBackground">#000</item>
+        <item name="colorSurface">#141414</item>
+        <item name="elevationOverlayEnabled">false</item>
+        <item name="colorNoteDefault">#000</item>
+        <item name="colorDrawerBackground">#040404</item>
+        <item name="colorBottomAppBarBackground">#000</item>
+        <item name="android:navigationBarColor">#000</item>
+    </style>
+
     <style name="Blue">
         <item name="colorPrimary">#2196f3</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -47,7 +47,7 @@
 
     <style name="DarkBlack">
         <item name="colorBackground">#000</item>
-        <item name="colorSurface">#141414</item>
+        <item name="colorSurface">#1B1B1B</item>
         <item name="elevationOverlayEnabled">false</item>
         <item name="colorNoteDefault">#000</item>
         <item name="colorDrawerBackground">#040404</item>


### PR DESCRIPTION
Adds an option to switch to a black background. This is useful for OLED screens.

I added another "Dark theme mode" selection preference and decided against putting it in the existing theme switcher, because this wouldn't allow the user to select "Follow system" and still be able to use black mode.

# Things to consider
- Icon and name of the preference are very similar to the "Theme mode" option, so any proposals on a better name/icon are welcome
- I experience "crashes" (Strict mode forced deaths) on my phone a few seconds after changing the theme. They don't occur on my emulator and I don't know what exactly causes them. Here's the stack trace:
```
2021-07-11 14:26:31.091 20749-20765/org.qosp.notes D/StrictMode: StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks. Callsite: readFromParcel
        at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1929)
        at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:305)
        at android.view.SurfaceControl.finalize(SurfaceControl.java:1107)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:291)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:278)
        at java.lang.Daemons$Daemon.run(Daemons.java:139)
        at java.lang.Thread.run(Thread.java:923)
```
Please also test this before releasing. Pointers as to why this happens are very much appreciated.
- It's harder to know where a note ends and where another starts. I think that tradeoff is worth it, and black mode is not the default.