### PR TITLE
Disable notebook swipe refresh when sync is not available

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
@@ -230,6 +230,7 @@ abstract class AbstractNotesFragment(@LayoutRes resId: Int) : BaseFragment(resId
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 swipeRefreshLayout.isRefreshing = false
+                swipeRefreshLayout.isEnabled = model.isSyncingEnabled()
 
                 val discardedNotes = activityModel
                     .discardEmptyNotesAsync()


### PR DESCRIPTION
As a user: I never set up sync and never worried about it. I was confused by the visual hint that there's a refresh action on scroll-to-top. Turns out there is no action.

I suggest disabling the hint when-if the action is not available.