### PR TITLE
Add German translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,291 @@
+<resources>
+    <!-- Navigation drawer -->
+    <string name="nav_notes">Notizen</string>
+    <string name="nav_archive">Archiv</string>
+    <string name="nav_deleted">Papierkorb</string>
+    <string name="nav_settings">Einstellungen</string>
+    <string name="nav_about">Über</string>
+    <string name="nav_tags">Tags</string>
+    <string name="nav_all_notes">Alle Notizen</string>
+    <string name="nav_notebooks">Notizbücher</string>
+    <string name="nav_your_notebooks">Deine Notizbücher</string>
+
+    <!-- Preferences -->
+    <string name="preferences_header_general">Allgemein</string>
+    <string name="preferences_theme_mode">Design</string>
+    <string name="preferences_theme_mode_dark">Dunkel</string>
+    <string name="preferences_theme_mode_light">Hell</string>
+    <string name="preferences_theme_mode_system">Systemstandard</string>
+
+    <string name="preferences_dark_theme_mode">Variante des dunklen Designs</string>
+    <string name="preferences_theme_dark_mode_standard">Standard</string>
+    <string name="preferences_theme_dark_mode_black">Schwarz</string>
+
+    <string name="preferences_header_view">Anzeige</string>
+    <string name="preferences_layout_mode">Layout</string>
+    <string name="preferences_layout_mode_grid">Kacheln</string>
+    <string name="preferences_layout_mode_list">Liste</string>
+
+    <string name="preferences_color_scheme">Farbschema</string>
+    <string name="preferences_color_scheme_blue">Blau</string>
+    <string name="preferences_color_scheme_pink">Rosa</string>
+    <string name="preferences_color_scheme_green">Grün</string>
+    <string name="preferences_color_scheme_orange">Orange</string>
+    <string name="preferences_color_scheme_purple">Violett</string>
+    <string name="preferences_color_scheme_yellow">Gelb</string>
+    <string name="preferences_color_scheme_red">Rot</string>
+
+    <string name="preferences_sort_method">Sortieren nach</string>
+    <string name="preferences_sort_method_title_asc">Titel (aufsteigend)</string>
+    <string name="preferences_sort_method_title_desc">Titel (absteigend)</string>
+    <string name="preferences_sort_method_created_asc">Erstelldatum (aufsteigend)</string>
+    <string name="preferences_sort_method_created_desc">Erstelldatum (absteigend)</string>
+    <string name="preferences_sort_method_modified_asc">Änderungsdatum (aufsteigend)</string>
+    <string name="preferences_sort_method_modified_desc">Änderungsdatum (absteigend)</string>
+
+    <string name="preferences_show_date">Erstell-/ Änderungsdatum anzeigen</string>
+    <string name="preferences_date_format">Datumsformat</string>
+    <string name="preferences_time_format">Zeitformat</string>
+
+    <string name="preferences_header_other">Sonstiges</string>
+    <string name="preferences_group_notes_without_notebook">Notizen gruppieren, die sich in keinem Notizbuch befinden</string>
+    <string name="preferences_open_media_in">Medien öffnen in</string>
+    <string name="preferences_open_media_in_internal">Internem Player</string>
+    <string name="preferences_open_media_in_external">Externem player</string>
+    <string name="preferences_note_deletion_time">Notizen im Papierkorb löschen</string>
+    <string name="preferences_note_deletion_time_instantly">Sofort</string>
+    <string name="preferences_note_deletion_time_week">Nach 7 Tagen</string>
+    <string name="preferences_note_deletion_time_two_weeks">Nach 14 Tagen</string>
+    <string name="preferences_note_deletion_time_month">Nach 30 Tagen</string>
+
+    <string name="preferences_header_backup">Sicherung</string>
+    <string name="preferences_create_backup">Erstelle ein Backup</string>
+    <string name="preferences_create_backup_subtext">Exportiere alle Notizen in eine Sicherungsdatei</string>
+    <string name="preferences_restore">Wiederherstellen</string>
+    <string name="preferences_restore_subtext">Lade Notizen aus einer Sicherungsdatei</string>
+    <string name="preferences_backup_strategy">Sicherungsstrategie für Anhänge</string>
+    <string name="preferences_backup_strategy_include_files">Alles sichern</string>
+    <string name="preferences_backup_strategy_keep_info">Nur Backup-Beschreibung und lokaler Pfad</string>
+    <string name="preferences_backup_strategy_keep_nothing">Anhänge nicht sichern</string>
+
+    <string name="preferences_header_syncing">Synchronisierung</string>
+    <string name="preferences_go_to_sync_settings">Synchronisierungseinstellungen</string>
+    <string name="preferences_currently_syncing_with">Wird derzeit mit %s synchronisiert</string>
+    <string name="preferences_currently_not_syncing">Wird derzeit nicht synchronisiert</string>
+    <string name="preferences_cloud_service">Synchronisierungsdienst</string>
+    <string name="preferences_cloud_service_disabled">Deaktiviert</string>
+    <string name="preferences_cloud_service_nextcloud">Nextcloud</string>
+    <string name="preferences_sync_experimental_warning">Die Synchronisierungsfunktion ist noch experimentell.\nDu kannst auf Fehler stoßen.</string>
+    <string name="preferences_nextcloud_limited_features">Denke daran, dass Nextcloud Notes keine Funktionen wie Tags, Anhänge, Erinnerungen, Aufgabenlisten und mehr unterstützt.</string>
+    <string name="preferences_nextcloud_account">Nextcloud-Konto</string>
+    <string name="preferences_nextcloud_instance_url">URL der Nextcloud-Instanz</string>
+    <string name="preferences_nextcloud_set_your_credentials">Hinterlege deine Zugangsdaten</string>
+    <string name="preferences_nextcloud_set_server_url">Hinterlege die URL des Servers</string>
+    <string name="preferences_sync_on_wifi">WLAN</string>
+    <string name="preferences_sync_on_wifi_data">WLAN oder mobile Daten</string>
+    <string name="preferences_sync_when_on">Synchronisieren, wenn eingeschaltet</string>
+    <string name="preferences_background_sync">Hintergrundsynchronisierung</string>
+    <string name="preferences_background_sync_enabled">Aktiviert</string>
+    <string name="preferences_background_sync_disabled">Deaktiviert</string>
+    <string name="preferences_new_notes_synchronizable">Neue Notizen synchronisierbar</string>
+
+
+    <!-- About -->
+    <string name="about_version">Version</string>
+    <string name="about_website">Webseite</string>
+    <string name="about_developer">Entwickler</string>
+    <string name="about_contribute">Contribute</string>
+    <string name="about_support">Unterstützung</string>
+    <string name="about_support_subtext">Die Erstellung und Pflege von Open-Source-Projekten ist zeitaufwendig und erzielt
+        keinen Gewinn.\nKauf den Entwicklern ein Bier!</string>
+    <string name="about_libraries">Bibliotheken</string>
+    <string name="about_libraries_subtext">Bibliotheken und Lizenzen von Drittanbietern anzeigen</string>
+
+
+    <!-- General -->
+    <string name="default_string">Standard</string>
+    <string name="yes">Ja</string>
+    <string name="no">Nein</string>
+    <string name="ok">Okay</string>
+    <string name="indicator_notes_empty">Deine Notizen erscheinen hier.</string>
+    <string name="indicator_untitled">Ohne Titel</string>
+    <string name="hint_username">Benutzername</string>
+    <string name="hint_password">Passwort</string>
+    <string name="action_save">Speichern</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_delete">Löschen</string>
+    <string name="action_done">Fertig!</string>
+    <string name="action_delete_permanently">Dauerhaft löschen</string>
+    <string name="action_select_all">Alle auswählen</string>
+    <string name="action_create_list">Liste erstellen</string>
+    <string name="action_show_hidden_notes">Versteckte Notizen anzeigen</string>
+    <string name="action_unarchive">Entarchivieren</string>
+    <string name="action_export">Exportieren</string>
+    <string name="action_hide">Ausblenden</string>
+    <string name="action_show">Einblenden</string>
+    <string name="action_archive">Archivieren</string>
+    <string name="action_pin">Anpinnen</string>
+    <string name="action_unpin">Loslösen</string>
+    <string name="action_restore">Wiederherstellen</string>
+    <string name="action_share">Teilen</string>
+    <string name="action_pin_unpin">Anpinnen / Loslösen</string>
+    <string name="action_move_to">Verschieben nach…</string>
+    <string name="action_duplicate">Duplizieren</string>
+    <string name="action_select_more">Mehr auswählen…</string>
+
+
+    <!-- Attachments -->
+    <string name="attachments_edit_description">Beschreibung bearbeiten</string>
+    <string name="attachments_hint_description">Beschreibung des Anhangs</string>
+    <string name="action_record_audio">Ton aufnehmen</string>
+    <string name="indicator_recording">Aufnahme (%1$s)</string>
+    <string name="action_attach_files">Dateien anhängen</string>
+    <string name="action_take_photo">Foto machen</string>
+    <string name="indicator_recorded_clip">Aufgenommener Clip</string>
+
+
+    <!-- Notebooks -->
+    <string name="default_notebook">Sonstiges</string>
+    <string name="notebooks_new_notebook">Neues Notizbuch</string>
+    <string name="notebooks_hint_name">Notizbuchname</string>
+    <string name="notebooks_unassigned">Kein Notizbuch</string>
+    <string name="indicator_notebook_empty">Du hast keine Notizbücher.</string>
+    <string name="action_create_notebook">Erstelle ein Notizbuch</string>
+    <string name="action_rename_notebook">Notizbuch umbenennen</string>
+    <string name="action_new_notebook">Neues Notizbuch</string>
+    <string name="indicator_notebook_already_exists">Notizbuch mit dem Namen %1$s existiert bereits.</string>
+
+
+    <!-- Archive -->
+    <string name="indicator_archive_empty">Deine archivierten Notizen werden hier angezeigt.</string>
+
+
+    <!-- Deleted -->
+    <string name="action_empty_bin">Papierkorb leeren</string>
+    <string name="empty_bin_warning_title">Bist du sicher?</string>
+    <string name="empty_bin_warning_text">Alle gelöschten Notizen gehen verloren.</string>
+    <string name="indicator_deleted_note_cannot_be_edited">Notizen im Papierkorb können nicht bearbeitet werden.</string>
+    <string name="indicator_deleted_empty">Deine gelöschten Notizen werden hier für %1$d Tage angezeigt.</string>
+    <string name="indicator_bin_disabled">Notizen werden sofort gelöscht.\nDas kann in den Einstellungen geändert werden.</string>
+    <string name="indicator_deleted_notes_permanently">Notizen wurden dauerhaft gelöscht.</string>
+    <string name="indicator_deleted_note_permanently">Notiz wurde dauerhaft gelöscht.</string>
+
+
+    <!-- Reminders -->
+    <string name="reminders">Erinnerungen</string>
+    <string name="reminder">Erinnerung</string>
+    <string name="reminders_hint_name">Erinnerungsname</string>
+    <string name="action_set_date">Datum einstellen</string>
+    <string name="action_set_time">Zeit einstellen</string>
+    <string name="action_new_reminder">Neue Erinnerung</string>
+    <string name="notification_reminder_fired">Du hast eine Erinnerung.</string>
+    <string name="indicator_cannot_set_past_reminder">Erinnerung kann nicht für ein vergangenes Datum eingestellt werden</string>
+
+
+    <!-- Tags -->
+    <string name="action_new_tag">Neuer Tag</string>
+    <string name="tags_hint_name">Name des Tags</string>
+    <string name="indicator_tags_empty">Du hast keine Tags.</string>
+    <string name="action_rename_tag">Tag umbenennen</string>
+    <string name="indicator_tag_already_exists">Tag mit dem Namen %1$s existiert bereits.</string>
+
+
+    <!-- Search -->
+    <string name="search_hint">Suche…</string>
+    <string name="action_search">Suche</string>
+    <string name="indicator_search_empty">Hier werden Suchergebnisse angezeigt.</string>
+    <string name="indicator_no_results_found">Keine Ergebnisse gefunden.</string>
+
+
+    <!-- Editor -->
+    <string name="editor_hint_title">Titel</string>
+    <string name="editor_hint_content">Erstelle eine Notiz!</string>
+    <string name="action_add_task">Aufgabe</string>
+    <string name="action_convert_to_note">In Notiz umwandeln</string>
+    <string name="action_convert_to_list">In Liste umwandeln</string>
+    <string name="action_do_not_sync">Nicht synchronisieren</string>
+    <string name="action_change_color">Farbe ändern</string>
+    <string name="action_enable_markdown">Markdown aktivieren</string>
+    <string name="action_disable_markdown">Markdown deaktivieren</string>
+    <string name="action_insert_bold_text">Fetten Markdown-Text einfügen</string>
+    <string name="action_insert_italics">Kursiven Markdown-Text einfügen</string>
+    <string name="action_insert_strikethrough">Durchgestrichenen Markdown-Text einfügen</string>
+    <string name="action_insert_heading">Markdown Überschrift einfügen</string>
+    <string name="action_insert_quote">Anführungszeichen einfügen</string>
+    <string name="action_insert_code">Code-Markdown einfügen</string>
+    <string name="indicator_note_date">Erstellt am %1$s\nZuletzt geändert am %2$s</string>
+    <string name="indicator_restored_notes">Wiederhergestellte Notizen</string>
+    <string name="indicator_restored_note">Notiz wiederhergestellt</string>
+    <string name="indicator_archived_notes">Archivierte Notizen</string>
+    <string name="indicator_archive_note">Archivierte Notiz</string>
+    <string name="indicator_moved_notes_to_bin">Notizen in den Papierkorb verschoben</string>
+    <string name="indicator_moved_note_to_bin">Notiz in den Papierkorb verschoben</string>
+    <string name="indicator_empty_note_discarded">Leere Notiz verworfen</string>
+    <string name="action_insert_link">Link einfügen</string>
+    <string name="action_insert">Einfügen</string>
+    <string name="action_insert_table">Tabelle einfügen</string>
+    <string name="message_invalid_number_rows_columns">Ungültige Anzahl von Zeilen und Spalten</string>
+    <string name="action_insert_image">Bild einfügen</string>
+    <string name="hint_image_description">Beschreibung</string>
+    <string name="hint_image_path">Bildpfad</string>
+    <string name="hint_hyperlink_text">Text</string>
+    <string name="hint_hyperlink_url">URL</string>
+    <string name="hint_number_columns">Anzahl der Spalten</string>
+    <string name="hint_number_rows">Reihenanzahl</string>
+    <string name="message_cannot_preview_table">Tabelle kann nicht in der Vorschau angezeigt werden.</string>
+
+    <!-- Backup / Restore -->
+    <string name="notification_backing_up">Sichern deiner Notizen…</string>
+    <string name="notification_backup_complete">Sicherung abgeschlossen!</string>
+    <string name="notification_backup_failed">Sicherung fehlgeschlagen</string>
+    <string name="notification_restoring_notes">Wiederherstellen deiner Notizen…</string>
+    <string name="notification_restore_complete">Wiederherstellung abgeschlossen</string>
+    <string name="notification_restore_failed">Wiederherstellung fehlgeschlagen</string>
+
+
+    <!-- Notification channels -->
+    <string name="notifications_channel_reminders">Erinnerungen</string>
+    <string name="notifications_channel_backups">Sicherungen</string>
+    <string name="notifications_channel_playback">Medienwiedergabe</string>
+
+    <!-- Syncing -->
+    <string name="message_not_valid_https">Dies ist keine gültige HTTPS-URL.</string>
+    <string name="indicator_nextcloud_currently_logged_in_as">Du bist derzeit eingeloggt als<b> %S</b> .</string>
+    <string name="indicator_nextcloud_currently_not_logged_in">Du bist derzeit nicht eingeloggt.</string>
+    <string name="action_nextcloud_authenticate">Authentifizieren</string>
+    <string name="indicator_offline_account">Offline-Konto</string>
+    <string name="indicator_connecting">Verbinde…</string>
+    <string name="message_something_went_wrong">Etwas ist schief gelaufen.</string>
+    <string name="message_invalid_credentials">Authentifizierung am Server aufgrund ungültiger Anmeldeinformationen fehlgeschlagen.</string>
+    <string name="message_logged_in_successfully">Erfolgreich eingeloggt!</string>
+    <string name="message_server_not_compatible">Die Serverversion ist mit dieser App nicht kompatibel.</string>
+    <string name="message_internet_not_available">Internetverbindung ist nicht verfügbar.</string>
+    <string name="message_credentials_cannot_be_blank">Anmeldeinformationen dürfen nicht leer sein.</string>
+    <string name="preference_nextcloud_clear_credentials">Anmeldedaten und Server-URL löschen</string>
+    <string name="notification_media_play_pause">Abspielen / Pause</string>
+    <string name="notification_media_stop">Stop</string>
+
+    <!-- App shortcuts -->
+    <string name="shortcut_take_note">Neue Notiz</string>
+    <string name="shortcut_make_list">Neue Liste</string>
+
+    <plurals name="more_items">
+        <item quantity="one">+%d Element</item>
+        <item quantity="other">+%d Elemente</item>
+    </plurals>
+
+    <plurals name="selected_notes">
+        <item quantity="one">%d Notiz ausgewählt</item>
+        <item quantity="other">%d Notizen ausgewählt</item>
+    </plurals>
+
+    <plurals name="selected_notebooks">
+        <item quantity="one">%d Notizbuch ausgewählt</item>
+        <item quantity="other">%d Notizbücher ausgewählt</item>
+    </plurals>
+
+    <plurals name="selected_tags">
+        <item quantity="one">%d Tag ausgewählt</item>
+        <item quantity="other">%d Tags ausgewählt</item>
+    </plurals>
+</resources>


### PR DESCRIPTION
Thanks for this awesome app! I just started using it regularly, so I created a German translation.

Unfortunately I saw that there already exists a PR for a German tranlation right _after_ I created it. In this other PR someone made some justified remarks. I think my translation would fix those _and_ is based on the newest develop version. Feel free to use it. 

Would be glad if I could also help in other improvements of the app. Let me know if you need any help.